### PR TITLE
Export `io.github.chrimle.classforge` Module

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+/** Forge Java Classes! */
+module io.github.chrimle.classforge {
+  exports io.github.chrimle.classforge;
+  exports io.github.chrimle.classforge.enums;
+
+  // Requires (non-static)
+  requires io.github.chrimle.exceptionfactory;
+  requires io.github.chrimle.semver;
+  requires java.compiler;
+
+  // Requires (static)
+  requires static org.apiguardian.api;
+  requires static org.jetbrains.annotations;
+}


### PR DESCRIPTION
> Modularizes the project and exports it as `io.github.chrimle.classforge`. **NOTE**: This is **MAY** be a **breaking change**, if the default `classforge` module name is used. If so, rename the `require` to use the new official module name.